### PR TITLE
Use (Q)GVAR macro in baseSpectator and searchIntel

### DIFF
--- a/functions/fn_baseSpectator.sqf
+++ b/functions/fn_baseSpectator.sqf
@@ -18,17 +18,17 @@
 params ["_player", "_object"];
 
 // Event for closing spectator from other machines
-["tac_baseSpectatorProhibit", {
+[QGVAR(baseSpectatorProhibit), {
     [false] call ACEFUNC(spectator,setSpectator);
 }, _player] call CBA_fnc_addEventHandlerArgs;
 
 // Player open spectator on specified object
 private _actionOpen = [
-    "tac_baseSpectatorOpen",
+    QGVAR(baseSpectatorOpen),
     "Open Spectator",
     "\a3\3den\data\cfg3den\camera\cameratexture_ca.paa",
     {[true, false] call ACEFUNC(spectator,setSpectator)}, // Forced by default (second parameter), non-forced allows user to exit
-    {(_this select 2) getVariable ["tac_baseSpectatorAllowed", false]},
+    {(_this select 2) getVariable [QGVAR(baseSpectatorAllowed), false]},
     {},
     _object
 ] call ACEFUNC(interact_menu,createAction);
@@ -38,12 +38,12 @@ private _actionOpen = [
 // Admin chat command to toggle spectator availability
 ["tac-spectator", {
     params ["_object"];
-    if (_object getVariable ["tac_baseSpectatorAllowed", false]) then {
-        ["tac_baseSpectatorProhibit", nil, call CBA_fnc_players] call CBA_fnc_targetEvent;
-        _object setVariable ["tac_baseSpectatorAllowed", false, true];
+    if (_object getVariable [QGVAR(baseSpectatorAllowed), false]) then {
+        [QGVAR(baseSpectatorProhibit), nil, call CBA_fnc_players] call CBA_fnc_targetEvent;
+        _object setVariable [QGVAR(baseSpectatorAllowed), false, true];
         ["ace_common_systemChatGlobal", "[TAC] Spectator Prohibited"] call CBA_fnc_globalEvent;
     } else {
-        _object setVariable ["tac_baseSpectatorAllowed", true, true];
+        _object setVariable [QGVAR(baseSpectatorAllowed), true, true];
         ["ace_common_systemChatGlobal", "[TAC] Spectator Allowed"] call CBA_fnc_globalEvent;
     };
 }, "admin", _object] call CBA_fnc_registerChatCommand;

--- a/functions/fn_searchIntel.sqf
+++ b/functions/fn_searchIntel.sqf
@@ -21,7 +21,7 @@
 params ["_controller", "_interactText", "_hintText", "_intelEntry", "_intelDescription"];
 
 private _actionSearch = [
-	format ["TAC_Scripts_searchIntel_%1", _controller],
+	format [QGVAR(searchIntel_%1), _controller],
 	_interactText,
 	"",
 	{


### PR DESCRIPTION
- Use macros where possible

**Needs testing!**

Will conflict with #2, will fix when either is merged.