### PR TITLE
Fix and improve Collect Intel

### DIFF
--- a/TAC-Mission-Template/CfgFunctions.hpp
+++ b/TAC-Mission-Template/CfgFunctions.hpp
@@ -8,6 +8,8 @@ class CfgFunctions {
             class baseSpectator;
             class briefing;
             class collectIntel;
+            class collectIntelPreInit { preInit = 1; };
+            class collectIntelPostInit { postInit = 1; };
         };
     };
 };

--- a/TAC-Mission-Template/functions/fn_collectIntel.sqf
+++ b/TAC-Mission-Template/functions/fn_collectIntel.sqf
@@ -2,6 +2,7 @@
  * Author: Kresky, Jonpas
  * Adds the ability to "pick up" objects, and add an intel entry in the briefing tab.
  * Call from initPlayerLocal.sqf
+ * Check for validity of object when using delete on collection (isNull)!
  *
  * Arguments:
  * 0: Object name (The object you want to "pick up") <OBJECT>
@@ -21,23 +22,25 @@
 
 params ["_controller", "_interactText", "_hintText", "_intelEntry", "_intelDescription", ["_deleteOnCollect", true]];
 
+// Add action
 private _actionPath = format [QGVAR(collectIntel_%1), _controller];
 private _actionCollectIntel = [
     _actionPath,
     _interactText,
     "",
     {
-        (_this select 2) params ["_actionCollectIntelPath", "_hintText", "_intelEntry", "_intelDescription", "_deleteOnCollect"];
+        (_this select 2) params ["_actionPath", "_hintText", "_intelEntry", "_intelDescription", "_deleteOnCollect"];
+
         [_hintText] call ACEFUNC(common,displayTextStructured);
-        [_player, ["Diary", [_intelEntry, _intelDescription]]] remoteExecCall ["createDiaryRecord", side _player, true];
+        [QGVAR(collectIntel_collect), [side group _player, ["Diary", [_intelEntry, _intelDescription]]]] call CBA_fnc_serverEvent;
 
         if (_deleteOnCollect) then {
             deleteVehicle _target;
         } else {
-            [_target, 0, ["ACE_MainActions", _actionPath]] call ACEFUNC(interact_menu,removeActionFromObject);
+            _target setVariable [QGVAR(collectIntel_collected), true, true];
         };
     },
-    {true},
+    {!(_target getVariable [QGVAR(collectIntel_collected), false])},
     {},
     [_actionPath, _hintText, _intelEntry, _intelDescription, _deleteOnCollect]
 ] call ACEFUNC(interact_menu,createAction);

--- a/TAC-Mission-Template/functions/fn_collectIntel.sqf
+++ b/TAC-Mission-Template/functions/fn_collectIntel.sqf
@@ -29,7 +29,7 @@ private _actionCollectIntel = [
     {
         (_this select 2) params ["_actionCollectIntelPath", "_hintText", "_intelEntry", "_intelDescription", "_deleteOnCollect"];
         [_hintText] call ACEFUNC(common,displayTextStructured);
-        [_player, ["Diary", [_intelEntry, _intelDescription]]] remoteExecCall ["createDiaryRecord", 0, true];
+        [_player, ["Diary", [_intelEntry, _intelDescription]]] remoteExecCall ["createDiaryRecord", side _player, true];
 
         if (_deleteOnCollect) then {
             deleteVehicle _target;

--- a/TAC-Mission-Template/functions/fn_collectIntel.sqf
+++ b/TAC-Mission-Template/functions/fn_collectIntel.sqf
@@ -21,24 +21,25 @@
 
 params ["_controller", "_interactText", "_hintText", "_intelEntry", "_intelDescription", ["_deleteOnCollect", true]];
 
+private _actionPath = format [QGVAR(collectIntel_%1), _controller];
 private _actionCollectIntel = [
-    format [QGVAR(collectIntel_%1), _controller],
+    _actionPath,
     _interactText,
     "",
     {
-        (_this select 2) params ["_hintText", "_intelEntry", "_intelDescription"];
+        (_this select 2) params ["_actionCollectIntelPath", "_hintText", "_intelEntry", "_intelDescription", "_deleteOnCollect"];
         [_hintText] call ACEFUNC(common,displayTextStructured);
         [_player, ["Diary", [_intelEntry, _intelDescription]]] remoteExecCall ["createDiaryRecord", 0, true];
 
         if (_deleteOnCollect) then {
             deleteVehicle _target;
         } else {
-            _target setVariable [QGVAR(collectedIntel), true, true];
+            [_target, 0, ["ACE_MainActions", _actionPath]] call ACEFUNC(interact_menu,removeActionFromObject);
         };
     },
-    {!(_target getVariable [QGVAR(collectedIntel), false])},
+    {true},
     {},
-    [_hintText, _intelEntry, _intelDescription, _deleteOnCollect]
+    [_actionPath, _hintText, _intelEntry, _intelDescription, _deleteOnCollect]
 ] call ACEFUNC(interact_menu,createAction);
 
 [_controller, 0, ["ACE_MainActions"], _actionCollectIntel] call ACEFUNC(interact_menu,addActionToObject);

--- a/TAC-Mission-Template/functions/fn_collectIntel.sqf
+++ b/TAC-Mission-Template/functions/fn_collectIntel.sqf
@@ -9,6 +9,7 @@
  * 2: Hint message <STRING>
  * 3: Diary/briefing entry tab name <STRING>
  * 4: Description/text the intel contains <STRING>
+ * 5: Delete on collect <BOOL> (default: true)
  *
  * Return Value:
  * None
@@ -18,21 +19,26 @@
  */
 #include "..\script_component.hpp"
 
-params ["_controller", "_interactText", "_hintText", "_intelEntry", "_intelDescription"];
+params ["_controller", "_interactText", "_hintText", "_intelEntry", "_intelDescription", ["_deleteOnCollect", true]];
 
 private _actionCollectIntel = [
     format [QGVAR(collectIntel_%1), _controller],
     _interactText,
     "",
     {
-       (_this select 2) params ["_hintText", "_intelEntry", "_intelDescription"];
-       [_hintText] call ACEFUNC(common,displayTextStructured);
-       [_player, ["Diary", [_intelEntry, _intelDescription]]] remoteExecCall ["createDiaryRecord", 0, true];
-       deleteVehicle this;
-   },
-   {true},
-   {},
-   [_hintText, _intelEntry, _intelDescription]
+        (_this select 2) params ["_hintText", "_intelEntry", "_intelDescription"];
+        [_hintText] call ACEFUNC(common,displayTextStructured);
+        [_player, ["Diary", [_intelEntry, _intelDescription]]] remoteExecCall ["createDiaryRecord", 0, true];
+
+        if (_deleteOnCollect) then {
+            deleteVehicle _target;
+        } else {
+            _target setVariable [QGVAR(collectedIntel), true, true];
+        };
+    },
+    {!(_target getVariable [QGVAR(collectedIntel), false])},
+    {},
+    [_hintText, _intelEntry, _intelDescription, _deleteOnCollect]
 ] call ACEFUNC(interact_menu,createAction);
 
 [_controller, 0, ["ACE_MainActions"], _actionCollectIntel] call ACEFUNC(interact_menu,addActionToObject);

--- a/TAC-Mission-Template/functions/fn_collectIntelPostInit.sqf
+++ b/TAC-Mission-Template/functions/fn_collectIntelPostInit.sqf
@@ -1,0 +1,21 @@
+/*
+ * Author: Kresky, Jonpas
+ * Initializes requirements for intel collection script.
+ * Called automatically in postInit.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["postInit", didJIP] call FUNC(collectIntelPostInit);
+ */
+#include "..\script_component.hpp"
+
+// Exit if not player client
+if (!hasInterface) exitWith {};
+
+// Request intel collected so far
+[QGVAR(collectIntel_updateRequest), ACE_player] call CBA_fnc_serverEvent;

--- a/TAC-Mission-Template/functions/fn_collectIntelPreInit.sqf
+++ b/TAC-Mission-Template/functions/fn_collectIntelPreInit.sqf
@@ -1,0 +1,45 @@
+/*
+ * Author: Kresky, Jonpas
+ * Initializes requirements for intel collection script.
+ * Called automatically in preInit.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["preInit"] call FUNC(collectIntelPreInit);
+ */
+#include "..\script_component.hpp"
+
+// Exit on Headless Client
+if (!isServer && !hasInterface) exitWith {};
+
+if (isServer) then {
+    // Track picked up records on server
+    GVAR(collectIntel_records) = [];
+
+    // Send all records saved so far (per request on load)
+    [QGVAR(collectIntel_updateRequest), {
+        params ["_player"];
+        [QGVAR(collectIntel_update), GVAR(collectIntel_records), _player] call CBA_fnc_targetEvent;
+    }] call CBA_fnc_addEventHandler;
+
+    // Save each picked up record and send it to others
+    [QGVAR(collectIntel_collect), {
+        GVAR(collectIntel_records) pushBack _this;
+        [QGVAR(collectIntel_update), [_this]] call CBA_fnc_globalEvent;
+    }] call CBA_fnc_addEventHandler;
+} else {
+    // Accept remote records and add them if of same side
+    [QGVAR(collectIntel_update), {
+        {
+            _x params ["_sideCollector", "_diaryRecord"];
+            if (_sideCollector == side group ACE_player) then {
+                ACE_player createDiaryRecord _diaryRecord;
+            };
+        } forEach _this;
+    }] call CBA_fnc_addEventHandler;
+};


### PR DESCRIPTION
- Fix collect intel networking (`createDiaryRecord` is not whitelisted for `remoteExec(Call)`) by switching to CBA events (in-line for easier inclusion/removal) - fix #8 
- Only broadcast collected intel to players (not server or headless client) on same side as the player who collected it, as well as player connecting later or rejoining (JIP)
- Add option to retain intel object (and prevent picking it up more than once)
- Fix indentation (was 3 spaces instead of 4)
