### PR TITLE
Add CBA Settings Has Settings File config entry

### DIFF
--- a/TAC-Mission-Template/description.ext
+++ b/TAC-Mission-Template/description.ext
@@ -27,3 +27,6 @@ respawnDialog = 0;
 disabledAI = 1;  // Disables AI for Playable Units
 enableDebugConsole[] = {"76561198048995566"};  // Enables Debug Console for players with specified UIDs (Jonpas) and Host/Admin
 enableTargetDebug = 1;
+
+// Other settings
+cba_settings_hasSettingsFile = 1;  // Enables use of "cba_settings.sqf", remove if file is not present (will crash)


### PR DESCRIPTION
CBA Settings' mission file `cba_settings.sqf` requires either a flag in the `mission.sqm` (added upon saving mission in Eden, if the settings file is present at that time) or this config entry.

I think we can safely do that since template always defines some settings. And should resolve issues with template files being added later on (like in making lobbies).