### PR TITLE
Improve ACEX Headless Blacklist temp fix

### DIFF
--- a/TAC-Mission-Template/initServer.sqf
+++ b/TAC-Mission-Template/initServer.sqf
@@ -1,3 +1,5 @@
 {
-   _x setVariable ["acex_headless_blacklist", false];
+    if !((_x getVariable ["acex_headless_blacklist", false]) isEqualTo true) then {
+        _x setVariable ["acex_headless_blacklist", false];
+    }
 } forEach allUnits;


### PR DESCRIPTION
Currently all units will get flagged out of blacklist, so if a mission maker flags some for blacklist (to not get transferred) that flag will just get ignored.

This should work, but is **NOT TESTED**.