### PR TITLE
Disable CUP emissive lights (lamp check) script

### DIFF
--- a/TAC-Mission-Template/Contract Template/initPlayerLocal.sqf
+++ b/TAC-Mission-Template/Contract Template/initPlayerLocal.sqf
@@ -4,3 +4,6 @@ params ["_player"];
 
 [_player, specScreen] call FUNC(baseSpectator);
 [_player] call FUNC(briefing);
+
+// Disable CUP street lights based on lighting levels (bad performance script)
+CUP_stopLampCheck = true;

--- a/TAC-Mission-Template/Non-Contract Template/initPlayerLocal.sqf
+++ b/TAC-Mission-Template/Non-Contract Template/initPlayerLocal.sqf
@@ -3,3 +3,6 @@
 params ["_player"];
 
 [_player] call FUNC(briefing);
+
+// Disable CUP street lights based on lighting levels (bad performance script)
+CUP_stopLampCheck = true;

--- a/TAC-Mission-Template/Zeus Template/initPlayerLocal.sqf
+++ b/TAC-Mission-Template/Zeus Template/initPlayerLocal.sqf
@@ -3,3 +3,6 @@
 params ["_player"];
 
 [_player] call FUNC(briefing);
+
+// Disable CUP street lights based on lighting levels (bad performance script)
+CUP_stopLampCheck = true;


### PR DESCRIPTION
It's a bad and badly performing script, running all the time, usually on top in profiling.

https://gist.github.com/JonBons/a8383bc46a8291170b85ad14449627e5

Might move to TAC Mods at some point, but intention is to improve or get rid of it in CUP itself.