### PR TITLE
Fix indfor briefing colour

### DIFF
--- a/Contract Template/functions/fn_briefing.sqf
+++ b/Contract Template/functions/fn_briefing.sqf
@@ -64,7 +64,7 @@ switch (side _player) do {
             <br/><font color='#1D69F6'>FRIENDLY FORCES:</font color>
             <br/>- Theseus Inc.
             <br/>
-            <br/><font color='#1D69F6'>INDEPENDENT FORCES:</font color>
+            <br/><font color='#139120'>INDEPENDENT FORCES:</font color>
             <br/>- Remove this section if there's no independent forces
             <br/>
             <br/><font color='#D81717'>ENEMY FORCES:</font color>

--- a/Theseus_Mission_Making_Guide.VR/functions/fn_briefing.sqf
+++ b/Theseus_Mission_Making_Guide.VR/functions/fn_briefing.sqf
@@ -64,7 +64,7 @@ switch (side _player) do {
             <br/><font color='#1D69F6'>FRIENDLY FORCES:</font color>
             <br/>- Theseus Inc.
             <br/>
-            <br/><font color='#1D69F6'>INDEPENDENT FORCES:</font color>
+            <br/><font color='#139120'>INDEPENDENT FORCES:</font color>
             <br/>- Remove this section if there's no independent forces
             <br/>
             <br/><font color='#D81717'>ENEMY FORCES:</font color>


### PR DESCRIPTION
Title, changes the colour of the `INDEPENDENT FORCES` text in the briefing.sqf from blue to green. Somehow missed that way back, and coincidentally noticed now.