### PR TITLE
Shorten Helios Command channel name

### DIFF
--- a/Contract Template/init.sqf
+++ b/Contract Template/init.sqf
@@ -13,6 +13,6 @@
     [_x, "theseus", 12, "label", "HELIOS 2"] call acre_api_fnc_setPresetChannelField;
     [_x, "theseus", 13, "label", "HELIOS 3"] call acre_api_fnc_setPresetChannelField;
     [_x, "theseus", 14, "label", "HELIOS 4"] call acre_api_fnc_setPresetChannelField;
-    [_x, "theseus", 15, "label", "HELIOS COMMAND"] call acre_api_fnc_setPresetChannelField;
+    [_x, "theseus", 15, "label", "HELIOS COMM"] call acre_api_fnc_setPresetChannelField;
     [_x, "theseus"] call acre_api_fnc_setPreset;
 } forEach ["ACRE_PRC152", "ACRE_PRC117F"];

--- a/Contract Template/init.sqf
+++ b/Contract Template/init.sqf
@@ -13,6 +13,6 @@
     [_x, "theseus", 12, "label", "HELIOS 2"] call acre_api_fnc_setPresetChannelField;
     [_x, "theseus", 13, "label", "HELIOS 3"] call acre_api_fnc_setPresetChannelField;
     [_x, "theseus", 14, "label", "HELIOS 4"] call acre_api_fnc_setPresetChannelField;
-    [_x, "theseus", 15, "label", "HELIOS COMM"] call acre_api_fnc_setPresetChannelField;
+    [_x, "theseus", 15, "label", "HELIOS CMND"] call acre_api_fnc_setPresetChannelField;
     [_x, "theseus"] call acre_api_fnc_setPreset;
 } forEach ["ACRE_PRC152", "ACRE_PRC117F"];


### PR DESCRIPTION
Maximum channel name length is 12 characters, this fixes overlap.

https://github.com/IDI-Systems/acre2/pull/946 technically does the same, but we are in control here.