### PR TITLE
Add ACRE2 God Mode configuration

### DIFF
--- a/Contract Template/initPlayerLocal.sqf
+++ b/Contract Template/initPlayerLocal.sqf
@@ -23,3 +23,15 @@ params ["_player", "_didJIP"];
 
 // Disable CUP street lights based on lighting levels (bad performance script)
 CUP_stopLampCheck = true;
+
+// ACRE2 God Mode
+private _admins = ["76561198048995566", "76561198085500182"];
+if ((getPlayerUID _player) in _admins) then {
+    [true, true] call acre_api_fnc_godModeConfigureAccess;
+    [_admins, 0] call acre_api_fnc_godModeModifyGroup;
+} else {
+    [{
+        IS_ADMIN || isServer // Logged-in admin or local host
+    }, 0] call acre_api_fnc_godModeModifyGroup;
+};
+["Admins", 0] call acre_api_fnc_godModeNameGroup;

--- a/Contract Template/initPlayerLocal.sqf
+++ b/Contract Template/initPlayerLocal.sqf
@@ -29,9 +29,5 @@ private _admins = ["76561198048995566", "76561198085500182"];
 if ((getPlayerUID _player) in _admins) then {
     [true, true] call acre_api_fnc_godModeConfigureAccess;
     [_admins, 0] call acre_api_fnc_godModeModifyGroup;
-} else {
-    [{
-        IS_ADMIN || isServer // Logged-in admin or local host
-    }, 0] call acre_api_fnc_godModeModifyGroup;
+    ["Admins", 0] call acre_api_fnc_godModeNameGroup;
 };
-["Admins", 0] call acre_api_fnc_godModeNameGroup;


### PR DESCRIPTION
**Needs testing!**

Adds ACRE2 [God Mode](https://acre2.idi-systems.com/wiki/user/god-mode) configuration allowing logged-in admins and Theseus Directors to access it in case of issues as a backup system.

Should be tested and prettified before merging.