### PR TITLE
Add ACRE2 God Mode configuration

### DIFF
--- a/Contract Template/CfgFunctions.hpp
+++ b/Contract Template/CfgFunctions.hpp
@@ -10,6 +10,7 @@ class CfgFunctions {
             class collectIntel;
             class collectIntelPreInit { preInit = 1; };
             class collectIntelPostInit { postInit = 1; };
+            class godMode;
         };
     };
 };

--- a/Contract Template/functions/fn_godMode.sqf
+++ b/Contract Template/functions/fn_godMode.sqf
@@ -1,0 +1,23 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Jonpas
+ * Sets up ACRE2 God Mode access and groups for Admins.
+ * Call from initPlayerLocal.sqf.
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] call FUNC(godMode);
+ */
+
+params ["_player"];
+
+if ((getPlayerUID _player) in ADMINS) then {
+    [true, true] call acre_api_fnc_godModeConfigureAccess;
+    [ADMINS, 0] call acre_api_fnc_godModeModifyGroup;
+    ["Admins", 0] call acre_api_fnc_godModeNameGroup;
+};

--- a/Contract Template/initPlayerLocal.sqf
+++ b/Contract Template/initPlayerLocal.sqf
@@ -20,6 +20,7 @@ params ["_player", "_didJIP"];
 
 [_player, specScreen] call FUNC(baseSpectator);
 [_player] call FUNC(briefing);
+[_player] call FUNC(godMode);
 
 // Disable CUP street lights based on lighting levels (bad performance script)
 CUP_stopLampCheck = true;

--- a/Contract Template/script_component.hpp
+++ b/Contract Template/script_component.hpp
@@ -37,3 +37,15 @@
 
 #define PATHTOTACF(var1,var2) PATHTOF_SYS(\x\tac\addons,var1,var2)
 #define QPATHTOTACF(var1,var2) QUOTE(PATHTOTACF(var1,var2))
+
+// Statics
+#define ADMINS [ \
+    "76561198048995566", /* Jonpas */ \
+    "76561198033169512", /* Kresky */ \
+    "76561197985332763", /* rg */ \
+    "76561198060588521", /* NevilleR */ \
+    "76561197975361559", /* grueneteufel */ \
+    "76561198085500182", /* Tyrone */ \
+    "76561198024182729", /* Laird */ \
+    "76561198324654204"  /* gilleedoo */ \
+]

--- a/Theseus_Mission_Making_Guide.VR/CfgFunctions.hpp
+++ b/Theseus_Mission_Making_Guide.VR/CfgFunctions.hpp
@@ -10,6 +10,7 @@ class CfgFunctions {
             class collectIntel;
             class collectIntelPreInit { preInit = 1; };
             class collectIntelPostInit { postInit = 1; };
+            class godMode;
         };
     };
 };

--- a/Theseus_Mission_Making_Guide.VR/functions/fn_godMode.sqf
+++ b/Theseus_Mission_Making_Guide.VR/functions/fn_godMode.sqf
@@ -1,0 +1,23 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Jonpas
+ * Sets up ACRE2 God Mode access and groups for Admins.
+ * Call from initPlayerLocal.sqf.
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] call FUNC(godMode);
+ */
+
+params ["_player"];
+
+if ((getPlayerUID _player) in ADMINS) then {
+    [true, true] call acre_api_fnc_godModeConfigureAccess;
+    [ADMINS, 0] call acre_api_fnc_godModeModifyGroup;
+    ["Admins", 0] call acre_api_fnc_godModeNameGroup;
+};

--- a/Theseus_Mission_Making_Guide.VR/initPlayerLocal.sqf
+++ b/Theseus_Mission_Making_Guide.VR/initPlayerLocal.sqf
@@ -20,6 +20,7 @@ params ["_player", "_didJIP"];
 
 [_player, specScreen] call FUNC(baseSpectator);
 [_player] call FUNC(briefing);
+[_player] call FUNC(godMode);
 
 // Disable CUP street lights based on lighting levels (bad performance script)
 CUP_stopLampCheck = true;

--- a/Theseus_Mission_Making_Guide.VR/script_component.hpp
+++ b/Theseus_Mission_Making_Guide.VR/script_component.hpp
@@ -37,3 +37,15 @@
 
 #define PATHTOTACF(var1,var2) PATHTOF_SYS(\x\tac\addons,var1,var2)
 #define QPATHTOTACF(var1,var2) QUOTE(PATHTOTACF(var1,var2))
+
+// Statics
+#define ADMINS [ \
+    "76561198048995566", /* Jonpas */ \
+    "76561198033169512", /* Kresky */ \
+    "76561197985332763", /* rg */ \
+    "76561198060588521", /* NevilleR */ \
+    "76561197975361559", /* grueneteufel */ \
+    "76561198085500182", /* Tyrone */ \
+    "76561198024182729", /* Laird */ \
+    "76561198324654204"  /* gilleedoo */ \
+]


### PR DESCRIPTION
Adds ACRE2 [God Mode](https://acre2.idi-systems.com/wiki/user/god-mode) configuration allowing admins (Directors and Seniors) to access it in case of issues as a backup system.

This time as function and includes all admins.

Logged-in admins can't be included as there is no event for it.