### PR TITLE
Add Respawned Gear Saving to cba settings

### DIFF
--- a/Contract Template/cba_settings.sqf
+++ b/Contract Template/cba_settings.sqf
@@ -2,4 +2,5 @@
 force tac_apollo_enabled = true;            // Set to 'false' to disable persistence for missions where we aren't using our own gear.
 
 // ACE Settings
+force ace_respawn_savePreDeathGear = false;  // Save and respawn with pre-set gear upon death. (NCO ONLY)
 force ace_weather_windSimulation = false;   // Wind based on the maps geographical location. Enabling this will override the settings you've set in EDEN.


### PR DESCRIPTION
- Adds the setting to `cba_settings.sqf` for NCO contracts where respawning with pre-set gear is necessary.