### PR TITLE
Hunt - Switch to doMove

### DIFF
--- a/Contract Template/functions/fn_hunt.sqf
+++ b/Contract Template/functions/fn_hunt.sqf
@@ -2,7 +2,6 @@
 /*
  * Author: Tyrone
  * Has an enemy group hunt a player group.
- * If units have waypoints they will return to them after a successful hunt.
  * If no hunted group is given it will select nearest player group within a given distance and target those.
  *
  * Call from Trigger with (isServer) check.
@@ -54,22 +53,22 @@ _hunters setCombatMode "RED";
         _nearest = _nearest param [0, objNull];
         _hunted = group _nearest;
         _args set [2, _hunted];
-    };
-    if (!isNull _hunted) then {
-        // Get Group Leaders
+    } else {
+        // Get hunted Leader
         private _huntedLeader = leader _hunted;
+        // doMove needs an array
+        private _hunterUnits = units _hunters;
 
         // Move to estimated hunted leader position
         private _huntedPos = _huntedLeader getPos [random 100, random 360];
-        _hunters move _huntedPos;
+        _hunterUnits doMove _huntedPos;
     };
 
     // Check for alive units
     private _huntersDead = {alive _x} count units _hunters == 0;
-    private _huntedDead = {alive _x} count units _hunted == 0;
 
     // Remove PFH.
-    if (_huntersDead || {_huntedDead && !isNull _hunted}) then {
+    if (_huntersDead) then {
         _handle call CBA_fnc_removePerFrameHandler;
     };
 }, _refresh, [_hunters, _refresh, _hunted, _searchDistance]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
- Hunted group can never be eliminated due to respawns. Cut out return to waypoint functionality.