### PR TITLE
Add smoke and illumination rounds to D30

### DIFF
--- a/scripts/fn_d30Strike.sqf
+++ b/scripts/fn_d30Strike.sqf
@@ -10,7 +10,7 @@
  * Ammo types are listed as HE (0), Cluster Smoke (1), Illumination (2).
  * Note that smoke and illumination rounds do not have whistling sound effects.
  * Barrage will have mortars select a new target for every round fired.
- * Do not use more than 3 cluster smoke rounds or graphics will cut smoke effedts.
+ * Do not use more than 3 cluster smoke rounds or graphics will cut smoke effects.
  * 1 Barrage will fire all shells at 1 target.
  *
  * Arguments:
@@ -29,7 +29,7 @@
  *
  */
 
-#define AMMO_TYPES ["CUP_30Rnd_122mmHE_D30_M","CUP_30Rnd_122mmSMOKE_D30_M","CUP_30Rnd_122mmILLUM_D30_M"]
+#define AMMO_TYPES ["CUP_30Rnd_122mmHE_D30_M", "CUP_30Rnd_122mmSMOKE_D30_M", "CUP_30Rnd_122mmILLUM_D30_M"]
 #define FIREMISSION_DELAY 3
 
 params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0], ["_barrages", 1]];

--- a/scripts/fn_d30Strike.sqf
+++ b/scripts/fn_d30Strike.sqf
@@ -7,8 +7,10 @@
  * If amount fired is 0 the amount is randomly selected between 1-8
  * Marker array can be set in init.sqf (See Example 2)
  * Marker array is randomly selected but all rounds fire on the same marker.
- * Ammo types are listed as HE (0).
+ * Ammo types are listed as HE (0), Cluster Smoke (1), Illumination (2).
+ * Note that smoke and illumination rounds do not have whistling sound effects.
  * Barrage will have mortars select a new target for every round fired.
+ * Do not use more than 3 cluster smoke rounds or graphics will cut smoke effedts.
  * 1 Barrage will fire all shells at 1 target.
  *
  * Arguments:
@@ -24,14 +26,32 @@
  * Examples:
  * [D30_1, ["Marker1", "Marker2"], 0, 0, 2] call TAC_Scripts_fnc_d30Strike;
  * [D30_1, tac_MarkerArray, 0, 0, 1] call TAC_Scripts_fnc_d30Strike;
+ *
  */
 
-#define AMMO_TYPES ["CUP_30Rnd_122mmHE_D30_M"]
+#define AMMO_TYPES ["CUP_30Rnd_122mmHE_D30_M","CUP_30Rnd_122mmSMOKE_D30_M","CUP_30Rnd_122mmILLUM_D30_M"]
 #define FIREMISSION_DELAY 3
 
 params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0], ["_barrages", 1]];
 
 private _ammo = AMMO_TYPES select _ammoType;
+
+//diag_log [_mortar, _randomPosition, _ammo, _amount];
+
+for "_i" from 0 to _barrages - 1 do {
+    private _randomMarker = selectRandom _markersArray;
+    private _randomPosition = [_randomMarker, true] call CBA_fnc_randPosArea;
+
+    if (_amount == 0) then {
+        _amount = random 8 + 1;
+    };
+
+    [{
+        params ["_mortar", "_randomPosition", "_ammo", "_amount"];
+        _mortar doArtilleryFire [_randomPosition, _ammo, _amount];
+        _mortar setVehicleAmmo 1;
+    }, [_mortar, _randomPosition, _ammo, _amount], _i * FIREMISSION_DELAY] call CBA_fnc_waitAndExecute;
+};
 
 //diag_log [_mortar, _randomPosition, _ammo, _amount];
 

--- a/scripts/fn_d30Strike.sqf
+++ b/scripts/fn_d30Strike.sqf
@@ -52,20 +52,3 @@ for "_i" from 0 to _barrages - 1 do {
         _mortar setVehicleAmmo 1;
     }, [_mortar, _randomPosition, _ammo, _amount], _i * FIREMISSION_DELAY] call CBA_fnc_waitAndExecute;
 };
-
-//diag_log [_mortar, _randomPosition, _ammo, _amount];
-
-for "_i" from 0 to _barrages - 1 do {
-    private _randomMarker = selectRandom _markersArray;
-    private _randomPosition = [_randomMarker, true] call CBA_fnc_randPosArea;
-
-    if (_amount == 0) then {
-        _amount = random 8 + 1;
-    };
-
-    [{
-        params ["_mortar", "_randomPosition", "_ammo", "_amount"];
-        _mortar doArtilleryFire [_randomPosition, _ammo, _amount];
-        _mortar setVehicleAmmo 1;
-    }, [_mortar, _randomPosition, _ammo, _amount], _i * FIREMISSION_DELAY] call CBA_fnc_waitAndExecute;
-};

--- a/scripts/fn_d30Strike.sqf
+++ b/scripts/fn_d30Strike.sqf
@@ -26,7 +26,6 @@
  * Examples:
  * [D30_1, ["Marker1", "Marker2"], 0, 0, 2] call TAC_Scripts_fnc_d30Strike;
  * [D30_1, tac_MarkerArray, 0, 0, 1] call TAC_Scripts_fnc_d30Strike;
- *
  */
 
 #define AMMO_TYPES ["CUP_30Rnd_122mmHE_D30_M", "CUP_30Rnd_122mmSMOKE_D30_M", "CUP_30Rnd_122mmILLUM_D30_M"]


### PR DESCRIPTION
Small change that allows the use of CUP cluster smoke rounds and cluster illum rounds from D30.  Tested fairly extensively, see tac_co_vae_victa_5 (forthcoming, talk to Jack).  Smoke rounds and illum rounds do not have the whistling effect that HE does, but otherwise function correctly.