### PR TITLE
Automate mission name

### DIFF
--- a/template/admin/initPlayerLocal.sqf
+++ b/template/admin/initPlayerLocal.sqf
@@ -16,9 +16,9 @@ CUP_stopLampCheck = true;
     params ["_missionName", "_mapName"];
     [
         [
-            [_missionName, "<t size = '1.5' underline = '1'>%1</t><br/>"],
+            [getMissionConfigValue ["onLoadName", ""], "<t size = '1.5' underline = '1'>%1</t><br/>"],
             ["Theseus Incorporated"],
-            [_mapName, "<t size = '1' font='puristaSemiBold'>%1</t>", 70]
+            [getText (configFile >> "CfgWorlds" >> worldName >> "description"), "<t size = '1' font='puristaSemiBold'>%1</t>", 70]
         ], 1, 0.75, "<t align = 'center' shadow = '1' size = '1.0'>%1</t>"
     ] spawn BIS_fnc_typeText;
 }] call CBA_fnc_addEventHandler;

--- a/template/admin/initPlayerLocal.sqf
+++ b/template/admin/initPlayerLocal.sqf
@@ -13,7 +13,6 @@ CUP_stopLampCheck = true;
 
 // Mission name event
 [QGVAR(missionName), {
-    params ["_missionName", "_mapName"];
     [
         [
             [getMissionConfigValue ["onLoadName", ""], "<t size = '1.5' underline = '1'>%1</t><br/>"],

--- a/template/admin/initServer.sqf
+++ b/template/admin/initServer.sqf
@@ -10,6 +10,9 @@ private _setMissionName = {
     }, _this, _timeUntilStart] call CBA_fnc_waitAndExecute;
 };
 
+// Mission start notification
+[getMissionConfigValue ["onLoadName", ""], getText (configFile >> "CfgWorlds" >> worldName >> "description")] call _setMissionName;
+
 // Log given traits to RPT 70 minutes after mission start if apollo is enabled.
 if (TACGVAR(apollo,enabled)) then {
     [{

--- a/template/admin/initServer.sqf
+++ b/template/admin/initServer.sqf
@@ -10,9 +10,6 @@ private _setMissionName = {
     }, _this, _timeUntilStart] call CBA_fnc_waitAndExecute;
 };
 
-// Mission start notification
-[getMissionConfigValue ["onLoadName", ""], getText (configFile >> "CfgWorlds" >> worldName >> "description")] call _setMissionName;
-
 // Log given traits to RPT 70 minutes after mission start if apollo is enabled.
 if (TACGVAR(apollo,enabled)) then {
     [{

--- a/template/admin/initServer.sqf
+++ b/template/admin/initServer.sqf
@@ -4,11 +4,10 @@
 systemTimeUTC params ["", "", "", "_hour", "_minute"];
 private _timeUntilStart = ((14 * 60) - (_hour * 60 + _minute)) * 60; // start time (1400z) - current time = time until start time
 
-private _setMissionName = {
-    [{
-        [QGVAR(missionName), _this] call CBA_fnc_globalEvent;
-    }, _this, _timeUntilStart] call CBA_fnc_waitAndExecute;
-};
+// Mission Name call on mission start
+[{
+    [QGVAR(missionName), _this] call CBA_fnc_globalEvent;
+}, _this, _timeUntilStart] call CBA_fnc_waitAndExecute;
 
 // Log given traits to RPT 70 minutes after mission start if apollo is enabled.
 if (TACGVAR(apollo,enabled)) then {

--- a/template/admin/initServer.sqf
+++ b/template/admin/initServer.sqf
@@ -6,8 +6,8 @@ private _timeUntilStart = ((14 * 60) - (_hour * 60 + _minute)) * 60; // start ti
 
 // Mission Name call on mission start
 [{
-    [QGVAR(missionName), _this] call CBA_fnc_globalEvent;
-}, _this, _timeUntilStart] call CBA_fnc_waitAndExecute;
+    [QGVAR(missionName), []] call CBA_fnc_globalEvent;
+}, [], _timeUntilStart] call CBA_fnc_waitAndExecute;
 
 // Log given traits to RPT 70 minutes after mission start if apollo is enabled.
 if (TACGVAR(apollo,enabled)) then {

--- a/template/initServer.sqf
+++ b/template/initServer.sqf
@@ -17,7 +17,7 @@
     #include "admin\initServer.sqf"
 
     // Mission start notification
-    ["MISSION NAME", "MAP NAME"] call _setMissionName;
+    [getMissionConfigValue ["onLoadName", ""], getText (configFile >> "CfgWorlds" >> worldName >> "description")] call _setMissionName;
 
     // START USER CODE
 

--- a/template/initServer.sqf
+++ b/template/initServer.sqf
@@ -16,9 +16,6 @@
 [{
     #include "admin\initServer.sqf"
 
-    // Mission start notification
-    [getMissionConfigValue ["onLoadName", ""], getText (configFile >> "CfgWorlds" >> worldName >> "description")] call _setMissionName;
-
     // START USER CODE
 
     // END USER CODE


### PR DESCRIPTION
- Moved to `admin\initServer` as it no longer needs to be touched.
- Grabs mission name with `getMissionConfigValue`
- Grabs proper world name with `getText (configFile >> "CfgWorlds" >> worldName >> "description")`

Works quite nicely.