### PR TITLE
Adding paradrop function

### DIFF
--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -143,7 +143,7 @@ _vehicle setVariable [QGVAR(paradropChuteHeight), _chuteHeight];
 // currently this is set for a drop interval of 1/2 second, allowing AI to keep cohesion
 // but not collide into each other
 
-// if  _groupAjudst is not used, then each group being parachuted will getOut a unit
+// if _groupAdjust is not used, then each group being parachuted will getOut a unit
 // at the same time as the forEach executes in parallel. 
 // Nominally, could use count units _x with _forEachIndex but will not work with groups
 // of different sizes

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -134,8 +134,8 @@ if(!_disableWP2) then {
 // Add the waypoint paradrop operation.  Eject automatically gives people a parachute 
 // Adds a key,value pair to the vehicle characteristics hash that can be referenced globally
 // No global variable names required
-_vehicle setVariable ['tac_dropGroups',_dropGroups];
-_vehicle setVariable ['tac_chuteHeight',_chuteHeight];
+_vehicle setVariable [QGVAR(paradropGroups), _dropGroups];
+_vehicle setVariable [QGVAR(paradropChuteHeight), _chuteHeight];
 
 // note - moveOut instantly pushes them out of vehicle without playing animation
 // this emulates a static line drop dropping very quickly, but needs to be spaced

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -1,21 +1,15 @@
 #include "..\script_component.hpp"
 /*
  * Author: Josh Vee, Jonpas, Veteran29
- * This is an all-purpose paradrop function meant to be called from waypoints
- * on a group piloting and aircraft and 1 or more groups to be dropped.
+ * An all-purpose paradrop function
+ * Call from vehicle waypoint with (isServer) check.
  * 
  * The vehicle will set move waypoints on two points of a circle surrounding 
  * a marker and initiate the drop at the fist waypoint.  Can be called multiple
  * times for different groups loaded on the same vehicle, but optimally
  * used either for single group on helicopter or multiple groups on planes.
  *
- * Conventional paradrop functions use the "Eject" action which has a lag for
- * animations; this makes each drop take about 3 seconds, much too slow
- * This instead uses getOut, which also requires spawning parachutes.
  * 
- * Call from move waypoints of the group piloting with (isServer) check.
- * Technically you could call the piloting group as the drop group,
- * which would result in the vehicle becoming unoccupied after the pilot drops.
  * 
  * It inserts waypoints in front of the one in which it is called
  * therefore it can be used with multiple waypoints without issue.
@@ -58,9 +52,9 @@
  * 0: Pilot Group <GROUP>
  * 1: Drop Groups <ARRAY>
  * 2: Drop Target <MARKER>
- * 3: Drop Mode <ARRAY> or <NUMBER> (Default 0)
- * 4: Reset Height <BOOLEAN> (Default false) 
- * 5: Disable Waypoint 2 (Default false)
+ * 3: Drop Mode <ARRAY> or <NUMBER> (default: 0)
+ * 4: Reset Height <BOOL> (default: false) 
+ * 5: Disable Waypoint 2 <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -76,7 +70,7 @@
 
 #define DROP_MODES [[150,1000,140],[105,1000,80],[250,1000,140],[4500,1000,900],[3000,1000,900]]
 
-params ["_pilotGroup","_dropGroups","_loc",["_dropMode",0],["_resetHeight",false],["_disableWP2",false]];
+params ["_pilotGroup", "_dropGroups", "_loc", ["_dropMode", 0], ["_resetHeight", false], ["_disableWP2", false]];
 
 if (_loc isEqualTo []) exitWith {};
 
@@ -97,7 +91,7 @@ if(isNull _vehicle) exitWith {}; // group not in vehicle
 
 private _origHeight = (getPosATL _vehicle) select 2;
 _vehicle flyInHeight _dropHeight; // set forced flying height
-if(_resetHeight) then {
+if (_resetHeight) then {
     [{
         params ["_vehicle"];
         (fullCrew [_vehicle,"cargo"]) isEqualTo []
@@ -116,7 +110,7 @@ private _dropRunOrigin = getPosATL _vehicle; // calling position from leader wil
 
 // Obtain a random location within drop target
 // Between current position and drop target, find angle
-private _dropTarget = [_loc,true] call CBA_fnc_randPosArea;
+private _dropTarget = [_loc, true] call CBA_fnc_randPosArea;
 
 if (_dropTarget isEqualTo []) exitWith {};
 
@@ -156,7 +150,7 @@ if (_minDistance < _dropLength) then {
 }; 
 
 private _dp = _pilotGroup addWaypoint [_dropZoneLocs select 1,-1,currentWaypoint _pilotGroup + 1,""];
-if(!_disableWP2) then {
+if (!_disableWP2) then {
     private _de = _pilotGroup addWaypoint [_dropZoneLocs select 0,-1,currentWaypoint _pilotGroup + 2,""];
 };
 

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -79,7 +79,7 @@ private _dropData = [];
 if (_dropMode isEqualType 0) then {
     _dropData = DROP_MODES select _dropMode;
 } else {
-    i f(_dropMode isEqualType [] && {count _dropMode == 3}) then {
+    if (_dropMode isEqualType [] && {count _dropMode == 3}) then {
         _dropData = _dropMode;
     };
 };

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -81,7 +81,7 @@ private _chuteHeight = 0;
 if (_dropMode isEqualType 0) then {
     _dropData = DROP_MODES select _dropMode;
 } else {
-    if(typeName _dropMode == "ARRAY" && count _dropMode == 3) then {
+    i f(_dropMode isEqualType [] && {count _dropMode == 3}) then {
         _dropHeight = _dropMode select 0;
         _dropLength = _dropMode select 1;
         _chuteHeight = _dropMode select 2;

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -76,7 +76,7 @@ private _dropData = [];
 // first process dropMode
 if (_dropMode isEqualType 0) then {
     if (_dropMode < 0 || {_dropMode > 4}) then {
-        ERROR_1("Paradrop mode %1 invalid - defaulting to 0!",_dropMode);
+        ERROR("Paradrop mode %1 invalid - defaulting to 0!",_dropMode);
         _dropMode = 0;
     };
     _dropData = DROP_MODES select _dropMode;
@@ -103,10 +103,6 @@ if (_resetHeight) then {
     }, [_vehicle, _origHeight]] call CBA_fnc_waitUntilAndExecute;
 };
 
-// next process waypoints if waypoints desired. 
-// if waypoint is desired, then script will be run on setWaypointStatements
-// if not then script will be run in this function.
-
 // Use addWayPoint for the group piloting the vehicle to add the drop waypoints
 private _dropRunOrigin = getPosATL _vehicle;
 
@@ -114,7 +110,7 @@ private _dropRunOrigin = getPosATL _vehicle;
 // Between current position and drop target, find angle
 private _dropTarget = [_loc, true] call CBA_fnc_randPosArea;
 
-if (_dropTarget isEqualTo []) exitWith {ERROR_1("Paradrop target for marker '%1' not found!",_loc)};
+if (_dropTarget isEqualTo []) exitWith {ERROR("Paradrop target for marker '%1' not found!",_loc)};
 
 private _fnc_dzLocs = {
     params ["_dropTarget", "_dropRunOrigin", "_dropLength"];
@@ -149,7 +145,7 @@ private _minDistance = _dropRunOrigin distance (_dropZoneLocs select 1);
 // Handling for when calling waypoint is within distance _dropLength
 if (_minDistance < _dropLength) then {
     _dropLength = _minDistance - 100; //arbitrary distance to allow for a helicopter turn
-    if (_dropLength < 0) exitWith {ERROR_1("Waypoint too close to DZ for drop!")};
+    if (_dropLength < 0) exitWith { exitWith { ERROR ("Waypoint too close to DZ for drop!")}; };
     _dropZoneLocs = [_dropTarget,_dropRunOrigin, _dropLength] call _fnc_dzLocs;
 }; 
 

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -155,8 +155,8 @@ _vehicle setVariable [QGVAR(paradropChuteHeight), _chuteHeight];
 
 private _fnc_dropParas = {
     private _vehicle = vehicle this; 
-    private _paraGroups = _vehicle getVariable ['tac_dropGroups', []];
-    private _chuteHeight = _vehicle getVariable ['tac_chuteHeight',[]];
+    private _paraGroups = _vehicle getVariable [QGVAR(paradropGroups), []];
+    private _chuteHeight = _vehicle getVariable [QGVAR(paradropChuteHeight), []];
     private _dropCount = _paraGroups apply {count units _x};
     private _groupAdjust = [];
     _groupAdjust resize (count _dropCount);
@@ -169,11 +169,10 @@ private _fnc_dropParas = {
         _groupAdjust set [_i,_sum];
     };
 
-    private _jumpFreq = 0.3;
-    if(speed _vehicle < 250) then {_jumpFreq = 0.5;};
+    private _jumpFreq = [0.3, 0.5] select (speed _vehicle < 250);
 
     {
-        units _x allowGetIn false;
+        (units _x) allowGetIn false;
         private _groupCount = _forEachIndex;
         {
             private _jumpDelay = _forEachIndex*_jumpFreq+(_groupAdjust select _groupCount)*_jumpFreq;

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -89,13 +89,16 @@ _dropData params ["_dropHeight", "_dropLength", "_chuteHeight"];
 private _vehicle = vehicle (leader _pilotGroup);
 if(isNull _vehicle) exitWith {}; // group not in vehicle
 
+private _origHeight = (getPosATL _vehicle) select 2;
 _vehicle flyInHeight _dropHeight; // set forced flying height
 if(_resetHeight) then {
-    [_vehicle] spawn {
+    [{
         params ["_vehicle"];
-        waitUntil {sleep 5; count (fullCrew [_vehicle,"cargo"]) == 0}; //checks every 5 seconds for all cargo exited
-        _vehicle flyInHeight 100; // this is the default value
-    };
+        (fullCrew [_vehicle,"cargo"]) isEqualTo []
+    }, {
+        params ["_vehicle", "_origHeight"];
+        _vehicle flyInHeight _origHeight;
+    }, [_vehicle, _origHeight]] call CBA_fnc_waitUntilAndExecute;
 };
 
 // next process waypoints if waypoints desired. 

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -88,6 +88,8 @@ if (_dropMode isEqualType 0) then {
     };
 };
 
+_dropData params ["_dropHeight", "_dropLength", "_chuteHeight"];
+
 private _vehicle = assignedVehicle (leader _pilotGroup);
 if(isNull _vehicle) exitWith {}; // then there's something seriously wrong here
 

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -78,7 +78,7 @@ private _dropHeight = 0;
 private _dropLength = 0;
 private _chuteHeight = 0;
 // first process dropMode
-if(typeName _dropMode == "SCALAR") then {
+if (_dropMode isEqualType 0) then {
     _dropHeight = (DROP_MODES select _dropMode) select 0;
     _dropLength = (DROP_MODES select _dropMode) select 1;
     _chuteHeight = (DROP_MODES select _dropMode) select 2;

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -191,7 +191,7 @@ private _fnc_dropParas = {
                     _chute setPosATL _manPos;
                     _man moveInDriver _chute;
                 }, _this] call CBA_fnc_waitUntilAndExecute;
-            },[_x,_chuteHeight],_jumpDelay] call CBA_fnc_waitAndExecute;
+            }, [_x, _chuteHeight, _vehicle] ,_jumpDelay] call CBA_fnc_waitAndExecute;
         } forEach units _x; 
     } forEach (_paraGroups select {local leader _x}); 
 };

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -145,8 +145,11 @@ private _minDistance = _dropRunOrigin distance (_dropZoneLocs select 1);
 // Handling for when calling waypoint is within distance _dropLength
 if (_minDistance < _dropLength) then {
     _dropLength = _minDistance - 100; //arbitrary distance to allow for a helicopter turn
-    if (_dropLength < 0) exitWith {exitWith{ERROR("Waypoint too close to DZ for drop!")};};
-    _dropZoneLocs = [_dropTarget,_dropRunOrigin, _dropLength] call _fnc_dzLocs;
+    if (_dropLength > 0) then {
+        _dropZoneLocs = [_dropTarget,_dropRunOrigin, _dropLength] call _fnc_dzLocs;
+    } else {
+        diag_log("Warning: Vehicle too close to DZ!");
+    };
 }; 
 
 private _dp = _pilotGroup addWaypoint [_dropZoneLocs select 1, -1,currentWaypoint _pilotGroup + 1, ""];

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -72,11 +72,20 @@ params ["_pilotGroup", "_dropGroups", "_loc", ["_dropMode", 0], ["_resetHeight",
 
 if (_loc isEqualTo "") exitWith {ERROR("Paradrop given invalid marker!")};
 
+// make sure you delete these 2 lines later below in the script (and this comment too)! I just moved them here as early exit is better, and we have a use for it early here now
+private _vehicle = vehicle (leader _pilotGroup);
+if (isNull _vehicle) exitWith {ERROR("Paradrop pilot group not in vehicle!")};
+
+private _origDropGroupsCount = count _dropGroups;
+_dropGroups = _dropGroups select {_vehicle != vehicle (leader _x)};
+if (count _dropGroups < _origDropGroupsCount) then {
+    WARNING_1("Paradrop %1 drop group(s) skipped because they are not in the same vehicle as pilot group!",_origDropGroupsCount - count _dropGroup)
+};
 private _dropData = [];
 // first process dropMode
 if (_dropMode isEqualType 0) then {
     if (_dropMode < 0 || {_dropMode > 4}) then {
-        ERROR("Paradrop mode %1 invalid - defaulting to 0!",_dropMode);
+        ERROR_1("Paradrop mode %1 invalid - defaulting to 0!",_dropMode);
         _dropMode = 0;
     };
     _dropData = DROP_MODES select _dropMode;
@@ -110,7 +119,7 @@ private _dropRunOrigin = getPosATL _vehicle;
 // Between current position and drop target, find angle
 private _dropTarget = [_loc, true] call CBA_fnc_randPosArea;
 
-if (_dropTarget isEqualTo []) exitWith {ERROR("Paradrop target for marker '%1' not found!",_loc)};
+if (_dropTarget isEqualTo []) exitWith {ERROR_1("Paradrop target for marker '%1' not found!",_loc)};
 
 private _fnc_dzLocs = {
     params ["_dropTarget", "_dropRunOrigin", "_dropLength"];

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -181,13 +181,17 @@ private _fnc_dropParas = {
                 private _chuteHeight = _this select 1;
                 unassignVehicle _man;
                 moveOut _man;
-                [_man, _chuteHeight] spawn {
-                    params ['_man','_chuteHeight'];
-                    waitUntil {sleep 0.5; ((getPosATL _man) select 2) <= _chuteHeight};
-                    _chute = createVehicle ['Steerable_Parachute_F', position _man, [], 0, 'FLY'];
-                    _chute setPos (getPosATL _man);
+                [{
+                    params ["_man", "_chuteHeight", "_vehicle"];
+                    (getPosATL _man) select 2 <= _chuteHeight && {_man distance _vehicle >= 15}
+                }, {
+                    params ["_man", "_chuteHeight"];
+
+                    private _manPos = getPosATL _man;
+                    private _chute = createVehicle ["Steerable_Parachute_F", _manPos, [], 0, "FLY"];
+                    _chute setPosATL _manPos;
                     _man moveInDriver _chute;
-                };
+                }, _this] call CBA_fnc_waitUntilAndExecute;
             },[_x,_chuteHeight],_jumpDelay] call CBA_fnc_waitAndExecute;
         } forEach units _x; 
     } forEach (_paraGroups select {local leader _x}); 

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -86,7 +86,7 @@ if (_dropMode isEqualType 0) then {
 
 _dropData params ["_dropHeight", "_dropLength", "_chuteHeight"];
 
-private _vehicle = assignedVehicle (leader _pilotGroup);
+private _vehicle = vehicle (leader _pilotGroup);
 if(isNull _vehicle) exitWith {}; // then there's something seriously wrong here
 
 _vehicle flyInHeight _dropHeight; // set forced flying height

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -1,0 +1,198 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Josh Vee, Jonpas, Veteran29
+ * This is an all-purpose paradrop function meant to be called from waypoints
+ * on a group piloting and aircraft and 1 or more groups to be dropped.
+ * 
+ * The vehicle will set move waypoints on two points of a circle surrounding 
+ * a marker and initiate the drop at the fist waypoint.  Can be called multiple
+ * times for different groups loaded on the same vehicle, but optimally
+ * used either for single group on helicopter or multiple groups on planes.
+ *
+ * Conventional paradrop functions use the "Eject" action which has a lag for
+ * animations; this makes each drop take about 3 seconds, much too slow
+ * This instead uses getOut, which also requires spawning parachutes.
+ * 
+ * Call from move waypoints of the group piloting with (isServer) check.
+ * Technically you could call the piloting group as the drop group,
+ * which would result in the vehicle becoming unoccupied after the pilot drops.
+ * 
+ * It inserts waypoints in front of the one in which it is called
+ * therefore it can be used with multiple waypoints without issue.
+ *
+ * Known behavior: 
+ * Locked planes/helicopters result in no drops.
+ * Planes/helicopters in combatMode "COMBAT" have altitude overrides.
+ *
+ * Optional Arguments: Drop Mode
+ * For convenience, this function has the following pre-set modes for drops:
+ * 0: Modern combat drop, 150m, parachutes deploy at 140m.
+ * 1: Dangerous combat drop, 90m, parachutes deploy at 80m. 
+ * 2: Training drop, 250m, parachutes deploy at 140m.
+ * 3: HALO drop, 4.5km, parachutes deploy at 900m.
+ * 4: Civilian drop, 3km, parachutes deploy at 900m. 
+ * For custom drops, drop altitude, drop zone length, deployment altitude can be set.
+ * 
+ * Note that for HALO or Civilian drops, most maps are not big enough to get to
+ * sufficient altitude and it is recommended to have several waypoints steadily
+ * increasing flyInHeight before using it.  Also, don't try with helicopters.
+ *
+ * Optional Arguments: Reset Height
+ * For drop purposes flyInHeight is set during the run.  If the transport is to be
+ * otherwise used after the run, set this to <true> in order to resume normal behavior
+ *
+ * Optional Arguments: Disable Waypoint 2
+ * Occasionally, AI behavior can be wonky especially when drop WPs are around airports.
+ * This will cause them to veer off from their drop direction and attempt to land. 
+ * Disabling WP 2 stops this behavior from occurring on the second waypoint.
+ * If it occurs on the first, I recommend changing the DZ area, the drop length,
+ * or the approach direction. 
+ *
+ * Arguments
+ * 0: Pilot Group <GROUP>
+ * 1: Drop Groups <ARRAY>
+ * 2: Drop Target <MARKER>
+ * 3: Drop Mode <ARRAY> or <NUMBER> (Default 0)
+ * 4: Reset Height <BOOLEAN> (Default false) 
+ * 5: Disable Waypoint 2 (Default false)
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * [pilot_group, [airborne_1], "drop_marker"] call TAC_Scripts_fnc_paradrop;
+ * [pilot_group, [airborne_1,airborne_2], "drop_marker"] call TAC_Scripts_fnc_paradrop;
+ * [pilot_group, [airborne_1], "drop_marker", 1] call TAC_Scripts_fnc_paradrop;
+ * [pilot_group, [airborne_1], "drop_marker", 0, false, false] call TAC_Scripts_fnc_paradrop;
+ * [pilot_group, [airborne_1], "drop_marker", [200,1000,150]] call TAC_Scripts_fnc_paradrop;
+ */
+
+
+#define DROP_MODES [[150,1000,140],[90,1000,80],[250,1000,140],[4500,1000,900],[3000,1000,900]]
+
+params ["_pilotGroup","_dropGroups","_loc",["_dropMode",0],["_resetHeight",false],["_disableWP2",false]];
+
+if(count _loc == 0) exitWith{};
+
+private _dropHeight = 0;
+private _dropLength = 0;
+private _chuteHeight = 0;
+// first process dropMode
+if(typeName _dropMode == "SCALAR") then {
+    _dropHeight = (DROP_MODES select _dropMode) select 0;
+    _dropLength = (DROP_MODES select _dropMode) select 1;
+    _chuteHeight = (DROP_MODES select _dropMode) select 2;
+} else {
+    if(typeName _dropMode == "ARRAY" && count _dropMode == 3) then {
+        _dropHeight = _dropMode select 0;
+        _dropLength = _dropMode select 1;
+        _chuteHeight = _dropMode select 2;
+    };
+};
+
+private _vehicle = assignedVehicle (leader _pilotGroup);
+if(isNull _vehicle) exitWith {}; // then there's something seriously wrong here
+
+_vehicle flyInHeight _dropHeight; // set forced flying height
+if(_resetHeight) then {
+    [_vehicle] spawn {
+        params ["_vehicle"];
+        waitUntil {sleep 5; count (fullCrew [_vehicle,"cargo"]) == 0}; //checks every 5 seconds for all cargo exited
+        _vehicle flyInHeight 100; // this is the default value
+    };
+};
+
+// next process waypoints if waypoints desired. 
+// if waypoint is desired, then script will be run on setWaypointStatements
+// if not then script will be run in this function.
+
+// Use addWayPoint for the group piloting the vehicle to add the drop waypoints
+private _dropRunOrigin = getPosATL _vehicle; // calling position from leader will call last position on the ground
+
+// Obtain a random location within drop target
+// Between current position and drop target, find angle
+private _dropTarget = [_loc,true] call CBA_fnc_randPosArea;
+
+private _theta = _dropRunOrigin getDir _dropTarget;
+
+// For a known drop point and known radius with azimuth _theta,
+// and radius r given by _dropLength/2,
+// then coordinates in the xy-plane relative to _dropTarget are:
+// +/- r*sin _theta for x (Easting) and +/- r*cos _theta for y (Northing)
+private _xDiff = _dropLength/2 * sin _theta;
+private _yDiff = _dropLength/2 * cos _theta;
+// set all coordinates based on DZ points in xy-plane; z coord does not matter
+// double lengths on second DZ coordinate to ensure straight line flight
+private _dropZoneLocs = [[(_dropTarget select 0) + 2*_xDiff,(_dropTarget select 1) + 2*_yDiff,_dropHeight],
+    [(_dropTarget select 1) - _xDiff,(_dropTarget select 1) - _yDiff,_dropHeight]];
+
+//expand waypoint 
+private _dp = _pilotGroup addWaypoint [_dropZoneLocs select 1,-1,currentWaypoint _pilotGroup + 1,""];
+if(!_disableWP2) then {
+    private _de = _pilotGroup addWaypoint [_dropZoneLocs select 0,-1,currentWaypoint _pilotGroup + 2,""];
+};
+
+// Add the waypoint paradrop operation.  Eject automatically gives people a parachute 
+// Adds a key,value pair to the vehicle characteristics hash that can be referenced globally
+// No global variable names required
+_vehicle setVariable ['tac_dropGroups',_dropGroups];
+_vehicle setVariable ['tac_chuteHeight',_chuteHeight];
+
+// note - moveOut instantly pushes them out of vehicle without playing animation
+// this emulates a static line drop dropping very quickly, but needs to be spaced
+// it also means that you need to spawn in a parachute otherwise they freefall to their deaths
+// currently this is set for a drop interval of 1/2 second, allowing AI to keep cohesion
+// but not collide into each other
+
+// if  _groupAjudst is not used, then each group being parachuted will getOut a unit
+// at the same time as the forEach executes in parallel. 
+// Nominally, could use count units _x with _forEachIndex but will not work with groups
+// of different sizes
+
+//  Other notes:
+//  Vehicles are unassigned and allowGetIn is set to false to prevent the paratroopers from
+//  running back to a landed plane or helicopter to get back in again.
+//  Velocity adjustment occurs to differentiate helicopters from planes to alter jump intervals
+
+private _fnc_dropParas = {
+    private _vehicle = vehicle this; 
+    private _paraGroups = _vehicle getVariable ['tac_dropGroups', []];
+    private _chuteHeight = _vehicle getVariable ['tac_chuteHeight',[]];
+    private _dropCount = _paraGroups apply {count units _x};
+    private _groupAdjust = [];
+    _groupAdjust resize (count _dropCount);
+
+    for "_i" from 0 to (count _dropCount)-1 do {
+        private _sum = 0;
+        for "_j" from 0 to _i do {
+            _sum = _sum + (_dropCount select _j);
+        };
+        _groupAdjust set [_i,_sum];
+    };
+
+    private _jumpFreq = 0.3;
+    if(speed _vehicle < 250) then {_jumpFreq = 0.5;};
+
+    {
+        units _x allowGetIn false;
+        private _groupCount = _forEachIndex;
+        {
+            private _jumpDelay = _forEachIndex*_jumpFreq+(_groupAdjust select _groupCount)*_jumpFreq;
+            [{
+                private _man = _this select 0;
+                private _chuteHeight = _this select 1;
+                unassignVehicle _man;
+                moveOut _man;
+                [_man, _chuteHeight] spawn {
+                    params ['_man','_chuteHeight'];
+                    waitUntil {sleep 0.5; ((getPosATL _man) select 2) <= _chuteHeight};
+                    _chute = createVehicle ['Steerable_Parachute_F', position _man, [], 0, 'FLY'];
+                    _chute setPos (getPosATL _man);
+                    _man moveInDriver _chute;
+                };
+            },[_x,_chuteHeight],_jumpDelay] call CBA_fnc_waitAndExecute;
+        } forEach units _x; 
+    } forEach (_paraGroups select {local leader _x}); 
+};
+
+_dp setWaypointStatements ["true",toString _fnc_dropParas];

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -72,7 +72,7 @@
 
 params ["_pilotGroup","_dropGroups","_loc",["_dropMode",0],["_resetHeight",false],["_disableWP2",false]];
 
-if(count _loc == 0) exitWith{};
+if (_loc isEqualTo []) exitWith {};
 
 private _dropHeight = 0;
 private _dropLength = 0;

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -82,9 +82,7 @@ if (_dropMode isEqualType 0) then {
     _dropData = DROP_MODES select _dropMode;
 } else {
     i f(_dropMode isEqualType [] && {count _dropMode == 3}) then {
-        _dropHeight = _dropMode select 0;
-        _dropLength = _dropMode select 1;
-        _chuteHeight = _dropMode select 2;
+        _dropData = _dropMode;
     };
 };
 

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -116,7 +116,7 @@ if (_dropTarget isEqualTo []) exitWith {};
 
     diag_log [_pilotGroup];
 private _fnc_dzLocs = {
-    params ["_dropTarget","_dropRunOrigin","_dropLength"];
+    params ["_dropTarget", "_dropRunOrigin", "_dropLength"];
     // getDir gives the azimuth, which differs in convention from trig
     // in two ways: (1) azimuth has zero origin at North and
     // (2) advances clockwise rather than counterclockwise

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -151,14 +151,9 @@ private _fnc_dzLocs = {
 private _dropZoneLocs = [_dropTarget, _dropRunOrigin, _dropLength] call _fnc_dzLocs;
 private _minDistance = _dropRunOrigin distance (_dropZoneLocs select 1);
 
-// Handling for when calling waypoint is within distance _dropLength
+// Error handling for when calling waypoint is within distance _dropLength
 if (_minDistance < _dropLength) then {
-    _dropLength = _minDistance - 100; //arbitrary distance to allow for a helicopter turn
-    if (_dropLength > 0) then {
-        _dropZoneLocs = [_dropTarget,_dropRunOrigin, _dropLength] call _fnc_dzLocs;
-    } else {
-        diag_log("Warning: Vehicle too close to DZ!");
-    };
+    WARNING_1("Paradrop vehicle '%1' too close to DZ!",_vehicle);
 }; 
 
 private _dp = _pilotGroup addWaypoint [_dropZoneLocs select 1, -1,currentWaypoint _pilotGroup + 1, ""];

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -145,7 +145,7 @@ private _minDistance = _dropRunOrigin distance (_dropZoneLocs select 1);
 // Handling for when calling waypoint is within distance _dropLength
 if (_minDistance < _dropLength) then {
     _dropLength = _minDistance - 100; //arbitrary distance to allow for a helicopter turn
-    if (_dropLength < 0) exitWith { exitWith { ERROR ("Waypoint too close to DZ for drop!")}; };
+    if (_dropLength < 0) exitWith {exitWith{ERROR("Waypoint too close to DZ for drop!")};};
     _dropZoneLocs = [_dropTarget,_dropRunOrigin, _dropLength] call _fnc_dzLocs;
 }; 
 

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -177,8 +177,7 @@ private _fnc_dropParas = {
         {
             private _jumpDelay = _forEachIndex*_jumpFreq+(_groupAdjust select _groupCount)*_jumpFreq;
             [{
-                private _man = _this select 0;
-                private _chuteHeight = _this select 1;
+                params ["_man"];
                 unassignVehicle _man;
                 moveOut _man;
                 [{

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -79,9 +79,7 @@ private _dropLength = 0;
 private _chuteHeight = 0;
 // first process dropMode
 if (_dropMode isEqualType 0) then {
-    _dropHeight = (DROP_MODES select _dropMode) select 0;
-    _dropLength = (DROP_MODES select _dropMode) select 1;
-    _chuteHeight = (DROP_MODES select _dropMode) select 2;
+    _dropData = DROP_MODES select _dropMode;
 } else {
     if(typeName _dropMode == "ARRAY" && count _dropMode == 3) then {
         _dropHeight = _dropMode select 0;

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -87,7 +87,7 @@ if (_dropMode isEqualType 0) then {
 _dropData params ["_dropHeight", "_dropLength", "_chuteHeight"];
 
 private _vehicle = vehicle (leader _pilotGroup);
-if(isNull _vehicle) exitWith {}; // then there's something seriously wrong here
+if(isNull _vehicle) exitWith {}; // group not in vehicle
 
 _vehicle flyInHeight _dropHeight; // set forced flying height
 if(_resetHeight) then {

--- a/scripts/fn_paradrop.sqf
+++ b/scripts/fn_paradrop.sqf
@@ -74,9 +74,7 @@ params ["_pilotGroup","_dropGroups","_loc",["_dropMode",0],["_resetHeight",false
 
 if (_loc isEqualTo []) exitWith {};
 
-private _dropHeight = 0;
-private _dropLength = 0;
-private _chuteHeight = 0;
+private _dropData = [];
 // first process dropMode
 if (_dropMode isEqualType 0) then {
     _dropData = DROP_MODES select _dropMode;


### PR DESCRIPTION
This is a function called from a waypoint of a group piloting an aircraft.  It inserts 1-2 waypoints directly ahead of the waypoint that calls it. Once the new waypoint is reached, the aircraft conducts a rapid paradrop of groups of infantry.
  
The main arguments are the group piloting the vehicle, an array of group(s) to be dropped, and a marker denoting the drop target, with optional arguments for specifying drop characteristics or subsequent aircraft behavior.  Several default drop options are provided, corresponding to combat drops, training drops, HALO drops and civilian skydiving drops.  Can be called with the group containing the pilot as the group to be dropped also, though obviously the vehicle will be uncrewed afterwards.

Script uses getOut rather than the "Eject" action because the latter option requires the unit to go through the ejection animation.  This causes the paradrop to take about 4 seconds per unit and makes paradropping impractical for dropping significant forces.

getOut pushes the unit out instantly, with no delay.  However, it doesn't spawn a parachute and when looped also creates a "blob" of infantry leaving the vehicle at the beginning of the run.  Consequently this function has an adjustment factor used to ensure that infantry are dropped in sequence rathe than all at once.  The frequency for a plane's (speed > 250 kph) is different from the one for helicopters.

Tested with helicopters (Mi-8T) and fixed wing transports (C-130, C-47) with individual and multiple groups.  Jump frequency is tuned to allow a C-47 going 330 kph to unload an entire troop load (48 passengers) in a 1km drop run.  Mission file available upon request. 

Credit given to jonpas and veteran29 who both helped immensely during development.  