### PR TITLE
Disable AAR if OCAP not loaded

### DIFF
--- a/template/functions/fn_aar.sqf
+++ b/template/functions/fn_aar.sqf
@@ -16,6 +16,10 @@
 
 params [["_timeUntilStart", 0]];
 
+if !(["OCAP"] call ACEFUNC(common,isModLoaded)) exitWith {
+    WARNING("AAR disabled - OCAP not loaded!");
+};
+
 // Functions
 FUNC(canStartAAR) = {
     isNil "ocap_capture" || {!ocap_capture}


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent continuous "AAR Started" messages (trying to start OCAP recording) when OCAP isn't actually loaded.
- Print a warning if AAR is setup but OCAP is not loaded.