### PR TITLE
Disable Auto-AAR on Manual-AAR interaction

### DIFF
--- a/template/admin/initPlayerLocal.sqf
+++ b/template/admin/initPlayerLocal.sqf
@@ -24,5 +24,5 @@ CUP_stopLampCheck = true;
 
 // Chat Commands
 ["tac-aar", {
-    [QGVAR(manualAAR), []] call CBA_fnc_serverEvent;
-}, "admin"] call CBA_fnc_registerChatCommand;
+    [QGVAR(manualAAR), _thisArgs] call CBA_fnc_serverEvent;
+}, "admin", [_player]] call CBA_fnc_registerChatCommand;


### PR DESCRIPTION
**When merged this pull request will:**
- Disable Auto-AAR on Manual-AAR interaction
- Add Manual-AAR stopping Auto-AAR safety - confirmation when running Auto-AAR gets converted to Manual-AAR
  - Whoever runs the chat command and if Auto-AAR is already running, will get a message to run it again as confirmation
- Log Manual-AAR executor to RPT
