### PR TITLE
Add Cave script

### DIFF
--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -47,7 +47,7 @@ _nightTime set [3, DATE_TIME];
     private _hasGPS = _player getVariable QGVAR(hasGPS);
     private _hasWatch = _player getVariable QGVAR(hasWatch);
 
-    if (_inArea >= 1) then {
+    if (_inArea >= 0) then {
         setDate _nightTime;
 
         // Wreck Radios

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -34,7 +34,7 @@
 _player setVariable [QGVAR(hasGPS), 0];
 _player setVariable [QGVAR(hasWatch), 0];
 
-// Wait 1 hour 5 minutes for gear check.
+// Wait 1 hour 5 minutes for gear check (default).
 [{
     params ["_player"];
     // Check if player has GPS

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -1,0 +1,106 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Mike
+ * Handles night-time cycle in caves, removes Map & MicroDAGR if player has one.
+ * Testing in single player or local multiplayer will not reset the date back to original, This is handled by syncing to the server date.
+ * Will check an array of markers instead of running multiple per frame handlers on players.
+ *
+ * Call from initPlayerLocal
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ * 1: Markers <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_player, ["Marker_1"]] call FUNC(caves);
+ * [_player, ["Marker_1", "Marker_2"]] call FUNC(caves);
+ */
+
+ params ["_player", "_markers"];
+
+#define DATE_TIME 23
+#define GEARCHECK_WAIT_TIME 3900
+#define CUSTOM_SIGNAL [0.05, -70]
+
+ private _nightTime = date;
+ _nightTime set [3, DATE_TIME];
+
+
+// SetVariable does 0 for unchecked, 1 for true and 2 for false.
+_player setVariable [QGVAR(hasGPS), 0];
+_player setVariable [QGVAR(hasWatch), 0];
+
+// Wait 1 hour 5 minutes for gear check.
+[{
+    params ["_player"];
+    // Check if player has GPS
+    if ((_player getVariable QGVAR(hasGPS)) == 0) then {
+        private _gpsCheck = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
+        if (_gpsCheck) then {
+            _player setVariable [QGVAR(hasGPS), 1];
+        } else {
+            _player setVariable [QGVAR(hasGPS), 2];
+        };
+    };
+
+    // Check if player has Watch
+    if ((_player getVariable QGVAR(hasWatch)) == 0) then {
+        private _watchCheck = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
+        if (_watchCheck) then {
+            _player setVariable [QGVAR(hasWatch), 1];
+        } else {
+            _player setVariable [QGVAR(hasWatch), 2];
+        };
+    };
+}, [_player], GEARCHECK_WAIT_TIME] call CBA_fnc_waitAndExecute;
+
+ [{
+     params ["_args", "_handle"];
+     _args params ["_player", "_markers", "_nightTime", ["_radioSet", false], ["_itemChecks", false]];
+
+    private _inArea = _markers findIf {_player inArea _x};
+    private _hasGPS = _player getVariable QGVAR(hasGPS);
+    private _hasWatch = _player getVariable QGVAR(hasWatch);
+
+    if (_inArea >= 1) then {
+        setDate _nightTime;
+
+        // Wreck Radios
+        if (!_radioSet) then {
+            [{CUSTOM_SIGNAL}] call acre_api_fnc_setCustomSignalFunc;
+            _args set [3, true];
+        };
+
+        // Remove Items
+        if (!_itemChecks) then {
+            if (_hasGPS == 1) then {
+                _player removeItem "ACE_microDAGR";
+            };
+            if (_hasWatch == 1) then {
+                _player unlinkItem "ItemWatch";
+            };
+            _args set [4, true];
+        };
+    };
+
+    if (_inArea == -1) then {
+        // Reset Radios
+        if (_radioSet) then {
+            _args set [3, false];
+            [{}] call acre_api_fnc_setCustomSignalFunc;
+        };
+        // Re-add removed items
+        if (_itemChecks) then {
+            if (_hasGPS == 1) then {
+                _player addItem "ACE_microDAGR";
+            };
+            if (_hasWatch == 1) then {
+                _player linkItem "ItemWatch";
+            };
+            _args set [4, false];
+        };
+    };
+}, 1, [_player, _markers, _nightTime]] call CBA_fnc_addPerFrameHandler;

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -3,13 +3,14 @@
  * Author: Mike
  * Handles night-time cycle in caves, removes Map & MicroDAGR if player has one.
  * Will check an array of markers instead of running multiple per frame handlers on players.
- * The time of day and custom ACRE signal can be edited in the defines.
  *
  * Call from initPlayerLocal.sqf.
  *
  * Arguments:
  * 0: Player <OBJECT>
  * 1: Markers <ARRAY>
+ * 2: Time <NUMBER> (Optional: Default 23)
+ * 3: Custom Signal <ARRAY> (Optional: Default [0.05, -70])
  *
  * Return Value:
  * None
@@ -19,17 +20,14 @@
  * [_player, ["Marker_1", "Marker_2"]] call FUNC(caves);
  */
 
-params ["_player", "_markers"];
-
-#define DATE_TIME 23
-#define CUSTOM_SIGNAL [0.05, -70]
+params ["_player", "_markers", ["_time", 23], ["_customSignal", [0.05, -70]]];
 
 private _nightTime = date;
-_nightTime set [3, DATE_TIME];
+_nightTime set [3, _time];
 
 [{
     params ["_args", "_handle"];
-    _args params ["_player", "_markers", "_nightTime", ["_radioSet", false], ["_itemChecks", false]];
+    _args params ["_player", "_markers", "_customSignal", "_nightTime", ["_radioSet", false], ["_itemChecks", false]];
 
     private _inArea = _markers findIf {_player inArea _x};
     private _hasGPS = _player getVariable [QGVAR(hasGPS), false];
@@ -40,8 +38,8 @@ _nightTime set [3, DATE_TIME];
 
         // Wreck Radios
         if (!_radioSet) then {
-            [{CUSTOM_SIGNAL}] call acre_api_fnc_setCustomSignalFunc;
-            _args set [3, true];
+            [{_customSignal}] call acre_api_fnc_setCustomSignalFunc;
+            _args set [4, true];
         };
 
         // Remove Items
@@ -60,7 +58,7 @@ _nightTime set [3, DATE_TIME];
             if (_hasWatch) then {
                 _player unlinkItem "ItemWatch";
             };
-            _args set [4, true];
+            _args set [5, true];
         };
     };
 
@@ -73,7 +71,7 @@ _nightTime set [3, DATE_TIME];
 
         // Reset Radios
         if (_radioSet) then {
-            _args set [3, false];
+            _args set [4, false];
             [{}] call acre_api_fnc_setCustomSignalFunc;
         };
 
@@ -85,7 +83,7 @@ _nightTime set [3, DATE_TIME];
             if (_hasWatch) then {
                 _player linkItem "ItemWatch";
             };
-            _args set [4, false];
+            _args set [5, false];
         };
     };
-}, 1, [_player, _markers, _nightTime]] call CBA_fnc_addPerFrameHandler;
+}, 1, [_player, _markers, _customSignal, _nightTime]] call CBA_fnc_addPerFrameHandler;

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -2,9 +2,8 @@
 /*
  * Author: Mike
  * Handles night-time cycle in caves, removes Map & MicroDAGR if player has one.
- * Testing in single player or local multiplayer will not reset the date back to original, This is handled by syncing to the server date.
  * Will check an array of markers instead of running multiple per frame handlers on players.
- * The time of day, how long it waits to check gear and custom ACRE signal can be edited in the defines.
+ * The time of day and custom ACRE signal can be edited in the defines.
  *
  * Call from initPlayerLocal
  *
@@ -20,47 +19,37 @@
  * [_player, ["Marker_1", "Marker_2"]] call FUNC(caves);
  */
 
- params ["_player", "_markers"];
+params ["_player", "_markers"];
 
 #define DATE_TIME 23
-#define GEARCHECK_WAIT_TIME 3900
 #define CUSTOM_SIGNAL [0.05, -70]
 
- private _nightTime = date;
- _nightTime set [3, DATE_TIME];
+private _nightTime = date;
+_nightTime set [3, DATE_TIME];
 
-
-// SetVariable does 0 for unchecked, 1 for true and 2 for false.
-_player setVariable [QGVAR(hasGPS), 0];
-_player setVariable [QGVAR(hasWatch), 0];
-
-// Wait 1 hour 5 minutes for gear check (default).
-[{
+// Check Gear Event
+[QGVAR(CaveGearCheck), {
     params ["_player"];
     // Check if player has GPS
-    if ((_player getVariable QGVAR(hasGPS)) == 0) then {
-        private _gpsCheck = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
-        if (_gpsCheck) then {
-            _player setVariable [QGVAR(hasGPS), 1];
-        } else {
-            _player setVariable [QGVAR(hasGPS), 2];
-        };
+    private _gpsCheck = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
+    if (_gpsCheck) then {
+        _player setVariable [QGVAR(hasGPS), true];
+    } else {
+        _player setVariable [QGVAR(hasGPS), false];
     };
 
     // Check if player has Watch
-    if ((_player getVariable QGVAR(hasWatch)) == 0) then {
-        private _watchCheck = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
-        if (_watchCheck) then {
-            _player setVariable [QGVAR(hasWatch), 1];
-        } else {
-            _player setVariable [QGVAR(hasWatch), 2];
-        };
+    private _watchCheck = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
+    if (_watchCheck) then {
+        _player setVariable [QGVAR(hasWatch), true];
+    } else {
+        _player setVariable [QGVAR(hasWatch), false];
     };
-}, [_player], GEARCHECK_WAIT_TIME] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;
 
- [{
-     params ["_args", "_handle"];
-     _args params ["_player", "_markers", "_nightTime", ["_radioSet", false], ["_itemChecks", false]];
+[{
+    params ["_args", "_handle"];
+    _args params ["_player", "_markers", "_nightTime", ["_radioSet", false], ["_itemChecks", false]];
 
     private _inArea = _markers findIf {_player inArea _x};
     private _hasGPS = _player getVariable QGVAR(hasGPS);
@@ -77,10 +66,11 @@ _player setVariable [QGVAR(hasWatch), 0];
 
         // Remove Items
         if (!_itemChecks) then {
-            if (_hasGPS == 1) then {
+            [QGVAR(CaveGearCheck), [_player]] call CBA_fnc_localEvent;
+            if (_hasGPS) then {
                 _player removeItem "ACE_microDAGR";
             };
-            if (_hasWatch == 1) then {
+            if (_hasWatch) then {
                 _player unlinkItem "ItemWatch";
             };
             _args set [4, true];
@@ -88,17 +78,24 @@ _player setVariable [QGVAR(hasWatch), 0];
     };
 
     if (_inArea == -1) then {
+        // Single/MP Testing
+        if (is3DENPreview) then {
+            private _testingDate = date;
+            _testingDate set [3, 10];
+        };
+
         // Reset Radios
         if (_radioSet) then {
             _args set [3, false];
             [{}] call acre_api_fnc_setCustomSignalFunc;
         };
+
         // Re-add removed items
         if (_itemChecks) then {
-            if (_hasGPS == 1) then {
+            if (_hasGPS) then {
                 _player addItem "ACE_microDAGR";
             };
-            if (_hasWatch == 1) then {
+            if (_hasWatch) then {
                 _player linkItem "ItemWatch";
             };
             _args set [4, false];

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -4,6 +4,7 @@
  * Handles night-time cycle in caves, removes Map & MicroDAGR if player has one.
  * Testing in single player or local multiplayer will not reset the date back to original, This is handled by syncing to the server date.
  * Will check an array of markers instead of running multiple per frame handlers on players.
+ * The time of day, how long it waits to check gear and custom ACRE signal can be edited in the defines.
  *
  * Call from initPlayerLocal
  *

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -27,25 +27,13 @@ params ["_player", "_markers"];
 private _nightTime = date;
 _nightTime set [3, DATE_TIME];
 
-// Check Gear Event
-[QGVAR(CaveGearCheck), {
-    params ["_player"];
-    // Check if player has GPS
-    private _gpsCheck = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
-    _player setVariable [QGVAR(hasGPS), _gpsCheck];
-
-    // Check if player has Watch
-    private _watchCheck = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
-    _player setVariable [QGVAR(hasWatch), _watchCheck];
-}] call CBA_fnc_addEventHandler;
-
 [{
     params ["_args", "_handle"];
     _args params ["_player", "_markers", "_nightTime", ["_radioSet", false], ["_itemChecks", false]];
 
     private _inArea = _markers findIf {_player inArea _x};
-    private _hasGPS = _player getVariable QGVAR(hasGPS);
-    private _hasWatch = _player getVariable QGVAR(hasWatch);
+    private _hasGPS = _player getVariable [QGVAR(hasGPS), false];
+    private _hasWatch = _player getVariable [QGVAR(hasWatch), false];
 
     if (_inArea >= 0) then {
         setDate _nightTime;
@@ -58,11 +46,18 @@ _nightTime set [3, DATE_TIME];
 
         // Remove Items
         if (!_itemChecks) then {
-            [QGVAR(CaveGearCheck), [_player]] call CBA_fnc_localEvent;
-            if (_hasGPS) then {
+            // Check if player has GPS
+            private _gpsCheck = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
+            _player setVariable [QGVAR(hasGPS), _gpsCheck];
+
+            // Check if player has Watch
+            private _watchCheck = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
+            _player setVariable [QGVAR(hasWatch), _watchCheck];
+
+            if (_gpsCheck) then {
                 _player removeItem "ACE_microDAGR";
             };
-            if (_hasWatch) then {
+            if (_watchCheck) then {
                 _player unlinkItem "ItemWatch";
             };
             _args set [4, true];

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -5,7 +5,7 @@
  * Will check an array of markers instead of running multiple per frame handlers on players.
  * The time of day and custom ACRE signal can be edited in the defines.
  *
- * Call from initPlayerLocal
+ * Call from initPlayerLocal.sqf.
  *
  * Arguments:
  * 0: Player <OBJECT>

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -32,19 +32,11 @@ _nightTime set [3, DATE_TIME];
     params ["_player"];
     // Check if player has GPS
     private _gpsCheck = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
-    if (_gpsCheck) then {
-        _player setVariable [QGVAR(hasGPS), true];
-    } else {
-        _player setVariable [QGVAR(hasGPS), false];
-    };
+    _player setVariable [QGVAR(hasGPS), _gpsCheck];
 
     // Check if player has Watch
     private _watchCheck = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
-    if (_watchCheck) then {
-        _player setVariable [QGVAR(hasWatch), true];
-    } else {
-        _player setVariable [QGVAR(hasWatch), false];
-    };
+    _player setVariable [QGVAR(hasWatch), _watchCheck];
 }] call CBA_fnc_addEventHandler;
 
 [{

--- a/scripts/fn_caves.sqf
+++ b/scripts/fn_caves.sqf
@@ -47,17 +47,17 @@ _nightTime set [3, DATE_TIME];
         // Remove Items
         if (!_itemChecks) then {
             // Check if player has GPS
-            private _gpsCheck = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
-            _player setVariable [QGVAR(hasGPS), _gpsCheck];
+            private _hasGps = "ACE_microDAGR" in ([_player] call CBA_fnc_uniqueUnitItems);
+            _player setVariable [QGVAR(hasGPS), _hasGps];
 
             // Check if player has Watch
-            private _watchCheck = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
-            _player setVariable [QGVAR(hasWatch), _watchCheck];
+            private _hasWatch = "ItemWatch" in ([_player] call CBA_fnc_uniqueUnitItems);
+            _player setVariable [QGVAR(hasWatch), _hasWatch];
 
-            if (_gpsCheck) then {
+            if (_hasGps) then {
                 _player removeItem "ACE_microDAGR";
             };
-            if (_watchCheck) then {
+            if (_hasWatch) then {
                 _player unlinkItem "ItemWatch";
             };
             _args set [4, true];


### PR DESCRIPTION
- Adds a PFH to spam `setDate` locally for darkness.
- Supports multiple markers
- Makes radios scrambled, can be disabled using params (restores radio on leaving area)
- Can decide on time of day using params
- Checks for Watch/GPS on entering area.
- Restores GPS & Watch if player had them after leaving area.
- If testing in Single/MP from the editor it will set the date to 10am after exiting area.