### PR TITLE
Add `apcSkill` function to `initServer`

### DIFF
--- a/template/admin/initServer.sqf
+++ b/template/admin/initServer.sqf
@@ -16,6 +16,9 @@ INFO_1("Time Until Start: %1",_timeUntilStart);
 // AAR
 [_timeUntilStart] call MFUNC(aar);
 
+// APC Skill
+[] call MFUNC(apcSkill);
+
 // Mission Name call on mission start
 [{
     [QGVAR(missionName), []] call CBA_fnc_globalEvent;


### PR DESCRIPTION
- title, APCs & Tanks are too strong/accurate for the most part, halves aimingAccuracy.
- Requires https://github.com/Theseus-Aegis/Mods/pull/579